### PR TITLE
Fix 'config file not found' on post install

### DIFF
--- a/tasks/nexus_post.yml
+++ b/tasks/nexus_post.yml
@@ -19,6 +19,10 @@
     dest: "{{ nexus_config_vmoptions_file_path }}"
   notify: Restart Nexus
 
+- name: Wait until Nexus config is created
+  wait_for:
+    path: "{{ nexus_config_file_path }}"
+    state: present
 
 - name: Configure Nexus
   template:


### PR DESCRIPTION
When installing for the first time, `nexus_config_file_path` will not be create until the service is ready. The script need to wait until the file is created.