### PR TITLE
Add systemd file descriptors limit

### DIFF
--- a/templates/nexus.service.j2
+++ b/templates/nexus.service.j2
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+LimitNOFILE=65536
 ExecStart={{ nexus_service_file_path }} start
 ExecStop={{ nexus_service_file_path }} stop
 User={{ nexus_user }}


### PR DESCRIPTION
The file descriptors limit value need to be set to `65536` according to Nexus OSS system requirement. The value can be fixed via systemd.

Reference: [Nexus OSS System Requirements](https://help.sonatype.com/repomanager3/system-requirements#SystemRequirements-Linux)