### PR TITLE
changed nexus download url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-nexus_version: 3.14.0-04
-nexus_download_url: "http://download.sonatype.com/nexus/3/nexus-{{ nexus_version }}-unix.tar.gz"
+nexus_version: 3.16.1-02
+nexus_download_url: "https://sonatype-download.global.ssl.fastly.net/repository/repositoryManager/3/nexus-{{ nexus_version }}-unix.tar.gz"
 nexus_install_tmp_base_dir: /tmp
 nexus_install_tmp_dir_name: "nexus-{{ nexus_version }}"
 nexus_install_tmp_dir: "{{ nexus_install_tmp_base_dir }}/{{ nexus_install_tmp_dir_name }}"


### PR DESCRIPTION
- Change Nexus download url. The old one is expired.
- Update Nexus version to 3.16.1-02.